### PR TITLE
feature/add-include-log-context-param: Add includeLogContext param

### DIFF
--- a/src/Contracts/FossabotCommander.php
+++ b/src/Contracts/FossabotCommander.php
@@ -137,6 +137,28 @@ interface FossabotCommander
     public function getLogging(): bool;
 
     /**
+     * Set whether to include additional context with logging messages.
+     *
+     * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @noinspection PhpMethodNamingConventionInspection
+     *
+     * @param bool $includeLogContext Whether to include additional context with logging messages
+     */
+    public function setIncludeLogContext(bool $includeLogContext): self;
+
+    /**
+     * Gets the configured logging context setting.
+     *
+     * @SuppressWarnings(PHPMD.BooleanGetMethodName)
+     *
+     * @noinspection PhpMethodNamingConventionInspection
+     *
+     * @return bool Logging context
+     */
+    public function getIncludeLogContext(): bool;
+
+    /**
      * Will execute a given {@link \Brandon14\FossabotCommander\Contracts\FossabotCommand} instance. If this method
      * throws a {@link \Brandon14\FossabotCommander\Contracts\Exceptions\CannotValidateRequestException}, then it was
      * unable to verify that the request came from Fossabot, and should be treated as a critical error.

--- a/tests/Feature/FossabotCommanderFeatureTest.php
+++ b/tests/Feature/FossabotCommanderFeatureTest.php
@@ -525,8 +525,7 @@ it('includes additional logging context by default', function () {
 
     $foss = new FossabotCommander($httpClient, $requestFactory, $logger, true);
 
-    $response = 'This is a test response.';
-    $command = new StubCommand($response);
+    $command = new StubCommand();
 
     $foss->runCommand($command, customToken());
 
@@ -555,8 +554,7 @@ it('includes additional logging context by default', function () {
     // Override include logging context.
     $foss->setIncludeLogContext(true);
 
-    $response = 'This is a test response.';
-    $command = new StubCommand($response);
+    $command = new StubCommand();
 
     $foss->runCommand($command, customToken());
 });
@@ -584,8 +582,7 @@ it('doesn\'t include additional logging context when instructed', function () {
 
     $foss = new FossabotCommander($httpClient, $requestFactory, $logger, true, false);
 
-    $response = 'This is a test response.';
-    $command = new StubCommand($response);
+    $command = new StubCommand();
 
     $foss->runCommand($command, customToken());
 
@@ -614,8 +611,7 @@ it('doesn\'t include additional logging context when instructed', function () {
     // Override include logging context.
     $foss->setIncludeLogContext(false);
 
-    $response = 'This is a test response.';
-    $command = new StubCommand($response);
+    $command = new StubCommand();
 
     $foss->runCommand($command, customToken());
 });

--- a/tests/Unit/FossabotCommanderTest.php
+++ b/tests/Unit/FossabotCommanderTest.php
@@ -227,3 +227,41 @@ it('gets logging context', function () {
 
     expect($context)->toBeArray();
 });
+
+it('sets include logging context', function () {
+    $httpClient = Mockery::mock(ClientInterface::class);
+    $requestFactory = Mockery::mock(RequestFactoryInterface::class);
+    $logger = Mockery::mock(LoggerInterface::class);
+
+    // Additional context enabled.
+    $foss = new FossabotCommander($httpClient, $requestFactory, $logger, true, true);
+    $foss->setIncludeLogContext(false);
+    $includeContext = $foss->getIncludeLogContext();
+
+    expect($includeContext)->toBeFalse();
+
+    // Additional context disabled.
+    $foss = new FossabotCommander($httpClient, $requestFactory, $logger, true, false);
+    $foss->setIncludeLogContext(true);
+    $includeContext = $foss->getIncludeLogContext();
+
+    expect($includeContext)->toBeTrue();
+});
+
+it('gets include logging context', function () {
+    $httpClient = Mockery::mock(ClientInterface::class);
+    $requestFactory = Mockery::mock(RequestFactoryInterface::class);
+    $logger = Mockery::mock(LoggerInterface::class);
+
+    // Additional context enabled.
+    $foss = new FossabotCommander($httpClient, $requestFactory, $logger, true, true);
+    $includeContext = $foss->getIncludeLogContext();
+
+    expect($includeContext)->toBeTrue();
+
+    // Additional context disabled.
+    $foss = new FossabotCommander($httpClient, $requestFactory, $logger, true, false);
+    $includeContext = $foss->getIncludeLogContext();
+
+    expect($includeContext)->toBeFalse();
+});


### PR DESCRIPTION
## Proposed Changes

- Adds an includeLogContext param to FossabotCommander to control whether additional logging context should be included with log messages.

- Add tests for new feature.
