### PR TITLE
release/1.0.2: Create release 1.0.2

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,4 @@
-name: ci
+name: cd
 on:
   push:
     branches: [main]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,7 +41,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "chore: Publish docs.yml"
-          file_pattern: "docs.yml/*"
+          file_pattern: "docs/*"
           add_options: "-f"
           skip_dirty_check: true
           commit_user_name: brandon14

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <a href="https://packagist.org/packages/brandon14/fossabot-commander" target="_blank"><img alt="Packagist PHP Version" src="https://img.shields.io/packagist/dependency-v/brandon14/fossabot-commander/php?style=for-the-badge&cacheSeconds=3600"></a>
 </p>
 <p align="center">
-  <a href="https://github.com/brandon14/fossabot-commander/actions/workflows/run-tests.yml" target="_blank"><img alt="GitHub Workflow Status (with event)" src="https://img.shields.io/github/actions/workflow/status/brandon14/fossabot-commander/run-tests.yml?style=for-the-badge&cacheSeconds=3600">
+  <a href="https://github.com/brandon14/fossabot-commander/actions/workflows/run-tests.yml" target="_blank"><img alt="GitHub Actions Workflow Status" src="https://img.shields.io/github/actions/workflow/status/brandon14/fossabot-commander/run-tests.yml?style=for-the-badge&cacheSeconds=3600">
   </a>
   <a href="https://codeclimate.com/github/brandon14/fossabot-commander/maintainability" target="_blank"><img alt="Code Climate maintainability" src="https://img.shields.io/codeclimate/maintainability-percentage/brandon14/fossabot-commander?style=for-the-badge&cacheSeconds=3600">
   </a>

--- a/src/Concerns/HandlesJsonable.php
+++ b/src/Concerns/HandlesJsonable.php
@@ -44,6 +44,8 @@ use Brandon14\FossabotCommander\Contracts\Exceptions\JsonParsingException;
  *
  * @mixin \Brandon14\FossabotCommander\Contracts\Arrayable
  *
+ * @internal
+ *
  * @author Brandon Clothier <brandon14125@gmail.com>
  */
 trait HandlesJsonable

--- a/src/Concerns/HandlesStringable.php
+++ b/src/Concerns/HandlesStringable.php
@@ -37,6 +37,8 @@ namespace Brandon14\FossabotCommander\Concerns;
  *
  * @noinspection PhpClassNamingConventionInspection
  *
+ * @internal
+ *
  * @author Brandon Clothier <brandon14125@gmail.com>
  */
 trait HandlesStringable

--- a/src/Context/FossabotDataModel.php
+++ b/src/Context/FossabotDataModel.php
@@ -44,7 +44,9 @@ use Brandon14\FossabotCommander\Contracts\Context\FossabotDataModel as FossabotD
 /**
  * Base Fossabot custom API data model.
  *
- * @see    https://docs.fossabot.com/variables/customapi#getting-context
+ * @see https://docs.fossabot.com/variables/customapi#getting-context
+ *
+ * @internal
  *
  * @author Brandon Clothier <brandon14125@gmail.com>
  */

--- a/src/Contracts/FossabotCommander.php
+++ b/src/Contracts/FossabotCommander.php
@@ -137,6 +137,28 @@ interface FossabotCommander
     public function getLogging(): bool;
 
     /**
+     * Set whether to include additional context with logging messages.
+     *
+     * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @noinspection PhpMethodNamingConventionInspection
+     *
+     * @param bool $includeLogContext Whether to include additional context with logging messages
+     */
+    public function setIncludeLogContext(bool $includeLogContext): self;
+
+    /**
+     * Gets the configured logging context setting.
+     *
+     * @SuppressWarnings(PHPMD.BooleanGetMethodName)
+     *
+     * @noinspection PhpMethodNamingConventionInspection
+     *
+     * @return bool Logging context
+     */
+    public function getIncludeLogContext(): bool;
+
+    /**
      * Will execute a given {@link \Brandon14\FossabotCommander\Contracts\FossabotCommand} instance. If this method
      * throws a {@link \Brandon14\FossabotCommander\Contracts\Exceptions\CannotValidateRequestException}, then it was
      * unable to verify that the request came from Fossabot, and should be treated as a critical error.

--- a/tests/Feature/FossabotCommanderFeatureTest.php
+++ b/tests/Feature/FossabotCommanderFeatureTest.php
@@ -33,7 +33,6 @@ use Psr\Log\LoggerInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Brandon14\FossabotCommander\FossabotCommander;
-use Brandon14\FossabotCommander\Tests\Stubs\StubCommand;
 use Brandon14\FossabotCommander\Contracts\FossabotCommand;
 use Brandon14\FossabotCommander\Contracts\Context\FossabotContext;
 use Brandon14\FossabotCommander\Contracts\Exceptions\RateLimitException;
@@ -53,15 +52,17 @@ it('returns a command', function () {
     $response = makeResponse(200, array_merge(standardHeaders(), rateLimitingHeaders()), validTokenBody());
     $contextResponse = makeResponse(200, array_merge(standardHeaders(), messageHeaders()), contextBody());
 
-    $requestFactory->allows('createRequest')->twice()->andReturns($request, $contextRequest);
-    $httpClient->allows('sendRequest')->twice()->andReturns($response, $contextResponse);
+    $requestFactory->shouldReceive('createRequest')->twice()->andReturns($request, $contextRequest);
+    $httpClient->shouldReceive('sendRequest')->twice()->andReturns($response, $contextResponse);
 
     $foss = new FossabotCommander($httpClient, $requestFactory);
-    $command = new StubCommand();
+
+    $response = 'This is a test response.';
+    $command = getStubCommand($response);
 
     $res = $foss->runCommand($command, customToken());
 
-    expect($res)->toEqual('Foo.');
+    expect($res)->toEqual($response);
 });
 
 it('handles invalid token on validate call', function () {
@@ -72,11 +73,13 @@ it('handles invalid token on validate call', function () {
     // Return an invalid token response during validation.
     $response = makeResponse(400, array_merge(standardHeaders(), rateLimitingHeaders()), invalidTokenBody());
 
-    $requestFactory->allows('createRequest')->once()->andReturns($request);
-    $httpClient->allows('sendRequest')->once()->andReturns($response);
+    $requestFactory->shouldReceive('createRequest')->once()->andReturns($request);
+    $httpClient->shouldReceive('sendRequest')->once()->andReturns($response);
 
     $foss = new FossabotCommander($httpClient, $requestFactory);
-    $command = new StubCommand();
+
+    $response = 'This is a test response.';
+    $command = getStubCommand($response);
 
     $foss->runCommand($command, customToken());
 })->throws(CannotValidateRequestException::class);
@@ -89,11 +92,13 @@ it('handles rate limiting on validate call', function () {
     // Return a rate limited response.
     $response = makeResponse(429, array_merge(standardHeaders(), rateLimitingHeaders()), rateLimitedBody());
 
-    $requestFactory->allows('createRequest')->once()->andReturns($request);
-    $httpClient->allows('sendRequest')->once()->andReturns($response);
+    $requestFactory->shouldReceive('createRequest')->once()->andReturns($request);
+    $httpClient->shouldReceive('sendRequest')->once()->andReturns($response);
 
     $foss = new FossabotCommander($httpClient, $requestFactory);
-    $command = new StubCommand();
+
+    $response = 'This is a test response.';
+    $command = getStubCommand($response);
 
     // Check that we get a RateLimitException and that the exception has the correct rate limit information context.
     try {
@@ -112,12 +117,14 @@ it('handles exceptions from HTTP client during validation', function () {
 
     $request = makeRequest(getFossabotUrl('/validate/'.customToken()));
 
-    $requestFactory->allows('createRequest')->once()->andReturns($request);
+    $requestFactory->shouldReceive('createRequest')->once()->andReturns($request);
     // We want to throw an exception on the validate request.
-    $httpClient->allows('sendRequest')->once()->andThrows(new RuntimeException());
+    $httpClient->shouldReceive('sendRequest')->once()->andThrows(new RuntimeException());
 
     $foss = new FossabotCommander($httpClient, $requestFactory);
-    $command = new StubCommand();
+
+    $response = 'This is a test response.';
+    $command = getStubCommand($response);
 
     $foss->runCommand($command, customToken());
 })->throws(CannotValidateRequestException::class);
@@ -130,11 +137,13 @@ it('handles non-200, non-400, non-429 exceptions during validation', function ()
     // Mock a 500 error when validating token.
     $response = makeResponse(500, array_merge(standardHeaders(), rateLimitingHeaders()), invalidTokenBody());
 
-    $requestFactory->allows('createRequest')->once()->andReturns($request);
-    $httpClient->allows('sendRequest')->once()->andReturns($response);
+    $requestFactory->shouldReceive('createRequest')->once()->andReturns($request);
+    $httpClient->shouldReceive('sendRequest')->once()->andReturns($response);
 
     $foss = new FossabotCommander($httpClient, $requestFactory);
-    $command = new StubCommand();
+
+    $response = 'This is a test response.';
+    $command = getStubCommand($response);
 
     $foss->runCommand($command, customToken());
 })->throws(CannotValidateRequestException::class);
@@ -147,9 +156,9 @@ it('handles exceptions from HTTP client during context', function () {
     $response = makeResponse(200, array_merge(standardHeaders(), rateLimitingHeaders()), validTokenBody());
     $contextRequest = makeRequest(getFossabotUrl('/context/'.customToken()));
 
-    $requestFactory->allows('createRequest')->twice()->andReturns($request, $contextRequest);
+    $requestFactory->shouldReceive('createRequest')->twice()->andReturns($request, $contextRequest);
     // We want to throw a generic exception on the second request when it would be getting the context.
-    $httpClient->allows('sendRequest')->twice()->andReturnUsing(static function () use ($response) {
+    $httpClient->shouldReceive('sendRequest')->twice()->andReturnUsing(static function () use ($response) {
         static $counter = 0;
 
         switch ($counter++) {
@@ -163,7 +172,9 @@ it('handles exceptions from HTTP client during context', function () {
     });
 
     $foss = new FossabotCommander($httpClient, $requestFactory);
-    $command = new StubCommand();
+
+    $response = 'This is a test response.';
+    $command = getStubCommand($response);
 
     $foss->runCommand($command, customToken());
 })->throws(FossabotCommanderException::class);
@@ -176,11 +187,11 @@ it('handles FossabotCommanderException exceptions from HTTP client during contex
     $response = makeResponse(200, array_merge(standardHeaders(), rateLimitingHeaders()), validTokenBody());
     $contextRequest = makeRequest(getFossabotUrl('/context/'.customToken()));
 
-    $requestFactory->allows('createRequest')->twice()->andReturns($request, $contextRequest);
+    $requestFactory->shouldReceive('createRequest')->twice()->andReturns($request, $contextRequest);
 
     $exception = new FossabotCommanderException('Foo.');
     // We want to throw a generic exception on the second request when it would be getting the context.
-    $httpClient->allows('sendRequest')->twice()->andReturnUsing(static function () use ($response, $exception) {
+    $httpClient->shouldReceive('sendRequest')->twice()->andReturnUsing(static function () use ($response, $exception) {
         static $counter = 0;
 
         switch ($counter++) {
@@ -194,7 +205,9 @@ it('handles FossabotCommanderException exceptions from HTTP client during contex
     });
 
     $foss = new FossabotCommander($httpClient, $requestFactory);
-    $command = new StubCommand();
+
+    $response = 'This is a test response.';
+    $command = getStubCommand($response);
 
     $foss->runCommand($command, customToken());
 })->throws(CannotGetContextException::class);
@@ -209,11 +222,13 @@ it('handles failing to get context', function () {
     // Mock invalid token error response on context request.
     $contextResponse = makeResponse(400, array_merge(standardHeaders(), messageHeaders()), invalidTokenBody());
 
-    $requestFactory->allows('createRequest')->twice()->andReturns($request, $contextRequest);
-    $httpClient->allows('sendRequest')->twice()->andReturns($response, $contextResponse);
+    $requestFactory->shouldReceive('createRequest')->twice()->andReturns($request, $contextRequest);
+    $httpClient->shouldReceive('sendRequest')->twice()->andReturns($response, $contextResponse);
 
     $foss = new FossabotCommander($httpClient, $requestFactory);
-    $command = new StubCommand();
+
+    $response = 'This is a test response.';
+    $command = getStubCommand($response);
 
     $foss->runCommand($command, customToken());
 })->throws(CannotGetContextException::class);
@@ -229,11 +244,13 @@ it('handles non-200, non-400, non-429 exceptions during context', function () {
     // Mock a 500 error when getting context.
     $contextResponse = makeResponse(500, array_merge(standardHeaders(), messageHeaders()), invalidTokenBody());
 
-    $requestFactory->allows('createRequest')->twice()->andReturns($request, $contextRequest);
-    $httpClient->allows('sendRequest')->twice()->andReturns($response, $contextResponse);
+    $requestFactory->shouldReceive('createRequest')->twice()->andReturns($request, $contextRequest);
+    $httpClient->shouldReceive('sendRequest')->twice()->andReturns($response, $contextResponse);
 
     $foss = new FossabotCommander($httpClient, $requestFactory);
-    $command = new StubCommand();
+
+    $response = 'This is a test response.';
+    $command = getStubCommand($response);
 
     $foss->runCommand($command, customToken());
 })->throws(CannotGetContextException::class);
@@ -247,17 +264,17 @@ it('handles getting context with no message property', function () {
     $response = makeResponse(200, array_merge(standardHeaders(), rateLimitingHeaders()), validTokenBody());
     $contextResponse = makeResponse(200, array_merge(standardHeaders(), messageHeaders()), contextNoMessageBody());
 
-    $requestFactory->allows('createRequest')->twice()->andReturns($request, $contextRequest);
-    $httpClient->allows('sendRequest')->twice()->andReturns($response, $contextResponse);
+    $requestFactory->shouldReceive('createRequest')->twice()->andReturns($request, $contextRequest);
+    $httpClient->shouldReceive('sendRequest')->twice()->andReturns($response, $contextResponse);
 
     $foss = new FossabotCommander($httpClient, $requestFactory);
 
     $command = Mockery::mock(FossabotCommand::class);
 
     // Ensure we get a context object with no message.
-    $command->allows('getResponse')->once()->withArgs(function ($context) {
+    $command->shouldReceive('getResponse')->once()->withArgs(function ($context) {
         return $context !== null && is_a($context, FossabotContext::class) && $context->message() === null;
-    })->andReturn('Foo.');
+    })->andReturn('This is a test response.');
 
     $foss->runCommand($command, customToken());
 });
@@ -269,17 +286,17 @@ it('skips getting context if getContext is false', function () {
     $request = makeRequest(getFossabotUrl('/validate/'.customToken()));
     $response = makeResponse(200, array_merge(standardHeaders(), rateLimitingHeaders()), validTokenBody());
 
-    $requestFactory->allows('createRequest')->once()->andReturns($request);
-    $httpClient->allows('sendRequest')->once()->andReturns($response);
+    $requestFactory->shouldReceive('createRequest')->once()->andReturns($request);
+    $httpClient->shouldReceive('sendRequest')->once()->andReturns($response);
 
     $foss = new FossabotCommander($httpClient, $requestFactory);
 
     $command = Mockery::mock(FossabotCommand::class);
 
     // Ensure we get no context passed to the command since we didn't fetch the context.
-    $command->allows('getResponse')->once()->withArgs(function ($context) {
+    $command->shouldReceive('getResponse')->once()->withArgs(function ($context) {
         return $context === null;
-    })->andReturn('Foo.');
+    })->andReturn('This is a test response.');
 
     $foss->runCommand($command, customToken(), false);
 });
@@ -293,11 +310,13 @@ it('handles rate limiting on context call', function () {
     // Return a rate limited response on the context call.
     $contextResponse = makeResponse(429, array_merge(standardHeaders(), rateLimitingHeaders()), rateLimitedBody());
 
-    $requestFactory->allows('createRequest')->twice()->andReturns($request, $contextRequest);
-    $httpClient->allows('sendRequest')->twice()->andReturns($response, $contextResponse);
+    $requestFactory->shouldReceive('createRequest')->twice()->andReturns($request, $contextRequest);
+    $httpClient->shouldReceive('sendRequest')->twice()->andReturns($response, $contextResponse);
 
     $foss = new FossabotCommander($httpClient, $requestFactory);
-    $command = new StubCommand();
+
+    $response = 'This is a test response.';
+    $command = getStubCommand($response);
 
     // Check that we get a RateLimitException and that the exception has the correct rate limit information context.
     try {
@@ -320,11 +339,13 @@ it('handles rate limiting when no rate limiting headers are found', function () 
     // Return a rate limited response on the context call. Don't provide rate limiting headers.
     $contextResponse = makeResponse(429, array_merge(standardHeaders(), []), rateLimitedBody());
 
-    $requestFactory->allows('createRequest')->twice()->andReturns($request, $contextRequest);
-    $httpClient->allows('sendRequest')->twice()->andReturns($response, $contextResponse);
+    $requestFactory->shouldReceive('createRequest')->twice()->andReturns($request, $contextRequest);
+    $httpClient->shouldReceive('sendRequest')->twice()->andReturns($response, $contextResponse);
 
     $foss = new FossabotCommander($httpClient, $requestFactory);
-    $command = new StubCommand();
+
+    $response = 'This is a test response.';
+    $command = getStubCommand($response);
 
     // Check that we get a InvalidStatusException and the exception code is 429 for rate limiting.
     try {
@@ -343,11 +364,13 @@ it('throws exception (CannotValidateRequestException) on invalid JSON during val
     // Cut some of JSON string off to give invalid JSON payload.
     $response = makeResponse(200, array_merge(standardHeaders(), rateLimitingHeaders()), mb_substr(validTokenBody(), 0, -5));
 
-    $requestFactory->allows('createRequest')->once()->andReturns($request);
-    $httpClient->allows('sendRequest')->once()->andReturns($response);
+    $requestFactory->shouldReceive('createRequest')->once()->andReturns($request);
+    $httpClient->shouldReceive('sendRequest')->once()->andReturns($response);
 
     $foss = new FossabotCommander($httpClient, $requestFactory);
-    $command = new StubCommand();
+
+    $response = 'This is a test response.';
+    $command = getStubCommand($response);
 
     $foss->runCommand($command, customToken());
 })->throws(CannotValidateRequestException::class);
@@ -362,11 +385,13 @@ it('throws exception (CannotGetContextException) on invalid JSON during context'
     // Trim some of the context JSON body off to give it invalid JSON.
     $contextResponse = makeResponse(200, array_merge(standardHeaders(), messageHeaders()), mb_substr(contextBody(), 0, -5));
 
-    $requestFactory->allows('createRequest')->twice()->andReturns($request, $contextRequest);
-    $httpClient->allows('sendRequest')->twice()->andReturns($response, $contextResponse);
+    $requestFactory->shouldReceive('createRequest')->twice()->andReturns($request, $contextRequest);
+    $httpClient->shouldReceive('sendRequest')->twice()->andReturns($response, $contextResponse);
 
     $foss = new FossabotCommander($httpClient, $requestFactory);
-    $command = new StubCommand();
+
+    $response = 'This is a test response.';
+    $command = getStubCommand($response);
 
     $foss->runCommand($command, customToken());
 })->throws(CannotGetContextException::class);
@@ -381,11 +406,13 @@ it('handles creating context data with invalid data', function () {
     // Use invalid context data here.
     $contextResponse = makeResponse(200, array_merge(standardHeaders(), messageHeaders()), invalidContextBody());
 
-    $requestFactory->allows('createRequest')->twice()->andReturns($request, $contextRequest);
-    $httpClient->allows('sendRequest')->twice()->andReturns($response, $contextResponse);
+    $requestFactory->shouldReceive('createRequest')->twice()->andReturns($request, $contextRequest);
+    $httpClient->shouldReceive('sendRequest')->twice()->andReturns($response, $contextResponse);
 
     $foss = new FossabotCommander($httpClient, $requestFactory);
-    $command = new StubCommand();
+
+    $response = 'This is a test response.';
+    $command = getStubCommand($response);
 
     $foss->runCommand($command, customToken());
 })->throws(CannotCreateContextException::class);
@@ -399,12 +426,14 @@ it('handles exceptions thrown from FossabotCommand::getResponse()', function () 
     $response = makeResponse(200, array_merge(standardHeaders(), rateLimitingHeaders()), validTokenBody());
     $contextResponse = makeResponse(200, array_merge(standardHeaders(), messageHeaders()), contextBody());
 
-    $requestFactory->allows('createRequest')->twice()->andReturns($request, $contextRequest);
-    $httpClient->allows('sendRequest')->twice()->andReturns($response, $contextResponse);
+    $requestFactory->shouldReceive('createRequest')->twice()->andReturns($request, $contextRequest);
+    $httpClient->shouldReceive('sendRequest')->twice()->andReturns($response, $contextResponse);
 
     $foss = new FossabotCommander($httpClient, $requestFactory);
+
     // Command will throw an exception when executed.
-    $command = new StubCommand(new RuntimeException('This is an exception.'));
+    $response = 'This is a test response.';
+    $command = getStubCommand($response, new RuntimeException('This is an exception.'));
 
     $foss->runCommand($command, customToken());
 })->throws(CannotExecuteCommandException::class);
@@ -419,13 +448,15 @@ it('makes calls to logger if provided', function () {
     $response = makeResponse(200, array_merge(standardHeaders(), rateLimitingHeaders()), validTokenBody());
     $contextResponse = makeResponse(200, array_merge(standardHeaders(), messageHeaders()), contextBody());
 
-    $requestFactory->allows('createRequest')->twice()->andReturns($request, $contextRequest);
-    $httpClient->allows('sendRequest')->twice()->andReturns($response, $contextResponse);
+    $requestFactory->shouldReceive('createRequest')->twice()->andReturns($request, $contextRequest);
+    $httpClient->shouldReceive('sendRequest')->twice()->andReturns($response, $contextResponse);
     // Ensure we make at least one call to the mocked logger.
-    $logger->allows('log')->atLeast()->once();
+    $logger->shouldReceive('log')->atLeast()->once();
 
     $foss = new FossabotCommander($httpClient, $requestFactory, $logger, true);
-    $command = new StubCommand();
+
+    $response = 'This is a test response.';
+    $command = getStubCommand($response);
 
     $foss->runCommand($command, customToken());
 });
@@ -440,14 +471,16 @@ it('disables logging', function () {
     $response = makeResponse(200, array_merge(standardHeaders(), rateLimitingHeaders()), validTokenBody());
     $contextResponse = makeResponse(200, array_merge(standardHeaders(), messageHeaders()), contextBody());
 
-    $requestFactory->allows('createRequest')->twice()->andReturns($request, $contextRequest);
-    $httpClient->allows('sendRequest')->twice()->andReturns($response, $contextResponse);
+    $requestFactory->shouldReceive('createRequest')->twice()->andReturns($request, $contextRequest);
+    $httpClient->shouldReceive('sendRequest')->twice()->andReturns($response, $contextResponse);
     // Ensure we don't make a call to log since logging is disabled.
-    $logger->allows('log')->never();
+    $logger->shouldReceive('log')->never();
 
     $foss = new FossabotCommander($httpClient, $requestFactory, $logger, true);
     $foss->disableLogging();
-    $command = new StubCommand();
+
+    $response = 'This is a test response.';
+    $command = getStubCommand($response);
 
     $foss->runCommand($command, customToken());
 });
@@ -462,15 +495,17 @@ it('enables logging', function () {
     $response = makeResponse(200, array_merge(standardHeaders(), rateLimitingHeaders()), validTokenBody());
     $contextResponse = makeResponse(200, array_merge(standardHeaders(), messageHeaders()), contextBody());
 
-    $requestFactory->allows('createRequest')->twice()->andReturns($request, $contextRequest);
-    $httpClient->allows('sendRequest')->twice()->andReturns($response, $contextResponse);
+    $requestFactory->shouldReceive('createRequest')->twice()->andReturns($request, $contextRequest);
+    $httpClient->shouldReceive('sendRequest')->twice()->andReturns($response, $contextResponse);
     // Ensure we make at least one call to the mocked logger.
-    $logger->allows('log')->atLeast()->once();
+    $logger->shouldReceive('log')->atLeast()->once();
 
-    // Disable logging when creating so we can enable it later.
+    // Disable logging when creating, so we can enable it later.
     $foss = new FossabotCommander($httpClient, $requestFactory, $logger, false);
     $foss->enableLogging();
-    $command = new StubCommand();
+
+    $response = 'This is a test response.';
+    $command = getStubCommand($response);
 
     $foss->runCommand($command, customToken());
 });

--- a/tests/Feature/FossabotCommanderFeatureTest.php
+++ b/tests/Feature/FossabotCommanderFeatureTest.php
@@ -560,7 +560,8 @@ it('includes additional logging context by default', function () {
 
     $foss = new FossabotCommander($httpClient, $requestFactory, $logger, true);
 
-    $command = new StubCommand();
+    $response = 'This is a test response.';
+    $command = getStubCommand($response);
 
     $foss->runCommand($command, customToken());
 
@@ -589,7 +590,8 @@ it('includes additional logging context by default', function () {
     // Override include logging context.
     $foss->setIncludeLogContext(true);
 
-    $command = new StubCommand();
+    $response = 'This is a test response.';
+    $command = getStubCommand($response);
 
     $foss->runCommand($command, customToken());
 });
@@ -617,7 +619,8 @@ it('doesn\'t include additional logging context when instructed', function () {
 
     $foss = new FossabotCommander($httpClient, $requestFactory, $logger, true, false);
 
-    $command = new StubCommand();
+    $response = 'This is a test response.';
+    $command = getStubCommand($response);
 
     $foss->runCommand($command, customToken());
 
@@ -646,7 +649,8 @@ it('doesn\'t include additional logging context when instructed', function () {
     // Override include logging context.
     $foss->setIncludeLogContext(false);
 
-    $command = new StubCommand();
+    $response = 'This is a test response.';
+    $command = getStubCommand($response);
 
     $foss->runCommand($command, customToken());
 });

--- a/tests/Feature/FossabotCommanderFeatureTest.php
+++ b/tests/Feature/FossabotCommanderFeatureTest.php
@@ -536,3 +536,117 @@ it('only allows setting null logger when logging is disabled', function () {
     // Logging is enabled, but we tried to null out the logger instance, should throw exception.
     $foss->setLog(null);
 })->throws(NoValidLoggerProvidedException::class);
+
+it('includes additional logging context by default', function () {
+    $httpClient = Mockery::mock(ClientInterface::class);
+    $requestFactory = Mockery::mock(RequestFactoryInterface::class);
+    $logger = Mockery::mock(LoggerInterface::class);
+
+    $request = makeRequest(getFossabotUrl('/validate/'.customToken()));
+    $contextRequest = makeRequest(getFossabotUrl('/context/'.customToken()));
+    $response = makeResponse(200, array_merge(standardHeaders(), rateLimitingHeaders()), validTokenBody());
+    $contextResponse = makeResponse(200, array_merge(standardHeaders(), messageHeaders()), contextBody());
+
+    $requestFactory->shouldReceive('createRequest')->twice()->andReturns($request, $contextRequest);
+    $httpClient->shouldReceive('sendRequest')->twice()->andReturns($response, $contextResponse);
+
+    // Assert that log was called with context.
+    $logger->shouldReceive('log')
+        ->atLeast()
+        ->once()
+        ->withArgs(static function ($level, $message, $context) {
+            return is_array($context) && count($context) > 0;
+        });
+
+    $foss = new FossabotCommander($httpClient, $requestFactory, $logger, true);
+
+    $command = new StubCommand();
+
+    $foss->runCommand($command, customToken());
+
+    // Test that overriding setIncludeLogContext adds logging context.
+    $httpClient = Mockery::mock(ClientInterface::class);
+    $requestFactory = Mockery::mock(RequestFactoryInterface::class);
+    $logger = Mockery::mock(LoggerInterface::class);
+
+    $request = makeRequest(getFossabotUrl('/validate/'.customToken()));
+    $contextRequest = makeRequest(getFossabotUrl('/context/'.customToken()));
+    $response = makeResponse(200, array_merge(standardHeaders(), rateLimitingHeaders()), validTokenBody());
+    $contextResponse = makeResponse(200, array_merge(standardHeaders(), messageHeaders()), contextBody());
+
+    $requestFactory->shouldReceive('createRequest')->twice()->andReturns($request, $contextRequest);
+    $httpClient->shouldReceive('sendRequest')->twice()->andReturns($response, $contextResponse);
+
+    // Assert that log was called with context.
+    $logger->shouldReceive('log')
+        ->atLeast()
+        ->once()
+        ->withArgs(static function ($level, $message, $context) {
+            return is_array($context) && count($context) > 0;
+        });
+
+    $foss = new FossabotCommander($httpClient, $requestFactory, $logger, true, false);
+    // Override include logging context.
+    $foss->setIncludeLogContext(true);
+
+    $command = new StubCommand();
+
+    $foss->runCommand($command, customToken());
+});
+
+it('doesn\'t include additional logging context when instructed', function () {
+    $httpClient = Mockery::mock(ClientInterface::class);
+    $requestFactory = Mockery::mock(RequestFactoryInterface::class);
+    $logger = Mockery::mock(LoggerInterface::class);
+
+    $request = makeRequest(getFossabotUrl('/validate/'.customToken()));
+    $contextRequest = makeRequest(getFossabotUrl('/context/'.customToken()));
+    $response = makeResponse(200, array_merge(standardHeaders(), rateLimitingHeaders()), validTokenBody());
+    $contextResponse = makeResponse(200, array_merge(standardHeaders(), messageHeaders()), contextBody());
+
+    $requestFactory->shouldReceive('createRequest')->twice()->andReturns($request, $contextRequest);
+    $httpClient->shouldReceive('sendRequest')->twice()->andReturns($response, $contextResponse);
+
+    // Assert that log was not called with context.
+    $logger->shouldReceive('log')
+        ->atLeast()
+        ->once()
+        ->withArgs(static function ($level, $message, $context) {
+            return is_array($context) && count($context) === 0;
+        });
+
+    $foss = new FossabotCommander($httpClient, $requestFactory, $logger, true, false);
+
+    $command = new StubCommand();
+
+    $foss->runCommand($command, customToken());
+
+    // Test that overriding setIncludeLogContext does not add logging context.
+    $httpClient = Mockery::mock(ClientInterface::class);
+    $requestFactory = Mockery::mock(RequestFactoryInterface::class);
+    $logger = Mockery::mock(LoggerInterface::class);
+
+    $request = makeRequest(getFossabotUrl('/validate/'.customToken()));
+    $contextRequest = makeRequest(getFossabotUrl('/context/'.customToken()));
+    $response = makeResponse(200, array_merge(standardHeaders(), rateLimitingHeaders()), validTokenBody());
+    $contextResponse = makeResponse(200, array_merge(standardHeaders(), messageHeaders()), contextBody());
+
+    $requestFactory->shouldReceive('createRequest')->twice()->andReturns($request, $contextRequest);
+    $httpClient->shouldReceive('sendRequest')->twice()->andReturns($response, $contextResponse);
+
+    // Assert that log was not called with context.
+    $logger->shouldReceive('log')
+        ->atLeast()
+        ->once()
+        ->withArgs(static function ($level, $message, $context) {
+            return is_array($context) && count($context) === 0;
+        });
+
+    $foss = new FossabotCommander($httpClient, $requestFactory, $logger, true, true);
+    // Override include logging context.
+    $foss->setIncludeLogContext(false);
+
+    $command = new StubCommand();
+
+    $foss->runCommand($command, customToken());
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -67,6 +67,8 @@ use GuzzleHttp\Psr7\Response;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Brandon14\FossabotCommander\Context\FossabotContext;
+use Brandon14\FossabotCommander\Tests\Stubs\StubCommand;
+use Brandon14\FossabotCommander\Contracts\FossabotCommand;
 use Brandon14\FossabotCommander\Contracts\Context\FossabotContext as FossabotContextInterface;
 
 // Custom functions for mocking data.
@@ -457,4 +459,17 @@ function contextNoRolesDataModel(): FossabotContextInterface
     $body['message']['user']['roles'] = [];
 
     return FossabotContext::createFromBody($body);
+}
+
+/**
+ * Returns a mock {@link \Brandon14\FossabotCommander\Contracts\FossabotCommand} to use in testing.
+ *
+ * @param string          $response  Command response
+ * @param \Throwable|null $exception Optional exception to throw from command
+ *
+ * @return \Brandon14\FossabotCommander\Contracts\FossabotCommand Command instance
+ */
+function getStubCommand(string $response = 'This is a test response.', ?Throwable $exception = null): FossabotCommand
+{
+    return new StubCommand($response, $exception);
 }

--- a/tests/Stubs/StubCommand.php
+++ b/tests/Stubs/StubCommand.php
@@ -43,6 +43,11 @@ use Brandon14\FossabotCommander\Contracts\Context\FossabotContext;
 final class StubCommand extends FossabotCommand
 {
     /**
+     * Command response string.
+     */
+    private string $response;
+
+    /**
      * Optional exception to be thrown during the response.
      */
     private ?Throwable $exception;
@@ -52,8 +57,9 @@ final class StubCommand extends FossabotCommand
      *
      * @param Throwable|null $exception Optional exception to throw during response
      */
-    public function __construct(?Throwable $exception = null)
+    public function __construct(string $response, ?Throwable $exception = null)
     {
+        $this->response = $response;
         $this->exception = $exception;
     }
 
@@ -66,6 +72,6 @@ final class StubCommand extends FossabotCommand
             throw $this->exception;
         }
 
-        return 'Foo.';
+        return $this->response;
     }
 }

--- a/tests/Unit/FossabotCommanderTest.php
+++ b/tests/Unit/FossabotCommanderTest.php
@@ -33,7 +33,6 @@ use Psr\Log\LoggerInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Brandon14\FossabotCommander\FossabotCommander;
-use Brandon14\FossabotCommander\Tests\Stubs\StubCommand;
 use Brandon14\FossabotCommander\Contracts\Context\FossabotContext;
 
 it('runs a command', function () {
@@ -49,12 +48,14 @@ it('runs a command', function () {
     $httpClient->allows('sendRequest')->twice()->andReturns($response, $contextResponse);
 
     $foss = new FossabotCommander($httpClient, $requestFactory);
-    $command = new StubCommand();
+
+    $response = 'This is a test response.';
+    $command = getStubCommand($response);
 
     $res = $foss->runCommand($command, customToken());
 
     expect($res)->toBeString()
-        ->and($res)->toEqual('Foo.');
+        ->and($res)->toEqual($response);
 });
 
 it('runs a callable command', function () {

--- a/tests/Unit/FossabotCommanderTest.php
+++ b/tests/Unit/FossabotCommanderTest.php
@@ -228,3 +228,41 @@ it('gets logging context', function () {
 
     expect($context)->toBeArray();
 });
+
+it('sets include logging context', function () {
+    $httpClient = Mockery::mock(ClientInterface::class);
+    $requestFactory = Mockery::mock(RequestFactoryInterface::class);
+    $logger = Mockery::mock(LoggerInterface::class);
+
+    // Additional context enabled.
+    $foss = new FossabotCommander($httpClient, $requestFactory, $logger, true, true);
+    $foss->setIncludeLogContext(false);
+    $includeContext = $foss->getIncludeLogContext();
+
+    expect($includeContext)->toBeFalse();
+
+    // Additional context disabled.
+    $foss = new FossabotCommander($httpClient, $requestFactory, $logger, true, false);
+    $foss->setIncludeLogContext(true);
+    $includeContext = $foss->getIncludeLogContext();
+
+    expect($includeContext)->toBeTrue();
+});
+
+it('gets include logging context', function () {
+    $httpClient = Mockery::mock(ClientInterface::class);
+    $requestFactory = Mockery::mock(RequestFactoryInterface::class);
+    $logger = Mockery::mock(LoggerInterface::class);
+
+    // Additional context enabled.
+    $foss = new FossabotCommander($httpClient, $requestFactory, $logger, true, true);
+    $includeContext = $foss->getIncludeLogContext();
+
+    expect($includeContext)->toBeTrue();
+
+    // Additional context disabled.
+    $foss = new FossabotCommander($httpClient, $requestFactory, $logger, true, false);
+    $includeContext = $foss->getIncludeLogContext();
+
+    expect($includeContext)->toBeFalse();
+});


### PR DESCRIPTION
## Proposed Changes

- Rename CI workflow to CD.
- Update Shields.io badge in README.md.
- Adds https://github.com/internal annotation to classes that are internal classes not to be used outside of the library.
- Add function to create StubCommand for testing.
- Use shouldRecieve() on mocks instead of allows().
- Allow passing in response string to StubCommand.
- Make function to create a StubCommand in pest.
- Adds an includeLogContext param to FossabotCommander to control whether additional logging context should be included with log messages.
- Add tests for new feature.
- Fixes the new includeLogContext feature tests with the new testing fixtures.
