### PR TITLE
release: v1.0.3 release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,7 +39,7 @@ jobs:
             commit_message: "chore: Update CHANGELOG.md"
             commit_user_name: brandon14
             commit_user_email: brandon14125@gmail.com
-            commit_options: '-S --force'
+            commit_options: '-S'
 
         - name: Update contributors
           uses: minicli/action-contributors@v3
@@ -61,4 +61,4 @@ jobs:
             commit_message: "chore: Update CONTRIBUTORS.md"
             commit_user_name: brandon14
             commit_user_email: brandon14125@gmail.com
-            commit_options: '-S --force'
+            commit_options: '-S'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,11 +36,12 @@ jobs:
         with:
           ref: gh-pages
           fetch-depth: 0
+          clean: false
 
       - name: Commit doc changes
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: "chore: Publish docs.yml"
+          commit_message: "chore: Publish docs"
           file_pattern: "docs/*"
           add_options: "-f"
           skip_dirty_check: true

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -39,4 +39,5 @@ jobs:
         with:
           commit_message: "chore: Fix styling from PHP-CS-Fixer"
           commit_user_name: brandon14
+          commit_user_email: brandon14125@gmail.com
           commit_options: '-S'


### PR DESCRIPTION
v1.0.3 release

- There were invalid commit options included in the CD workflow.

- This also adds the email to the php-cs-fixer workflow for committing.

- When checking back out to gh-pages after building the docs, we need to ensure it doesn't clean the repo as it will drop all the docs generated.